### PR TITLE
fix: properly calculate commit sha for annotated tags

### DIFF
--- a/internal/semver/convcommits.go
+++ b/internal/semver/convcommits.go
@@ -67,7 +67,14 @@ func (cc *ConventionalCommits) SemVer() (*SemVer, error) {
 	tagRefs := map[string]string{}
 	err = tags.ForEach(func(ref *plumbing.Reference) error {
 		if cc.prefix == "" || strings.HasPrefix(ref.Name().Short(), cc.prefix) {
-			tagRefs[ref.Hash().String()] = ref.Name().Short()
+			var sha plumbing.Hash
+			annotatedTag, _ := cc.gitRepo.TagObject(ref.Hash())
+			if annotatedTag != nil {
+				sha = annotatedTag.Target
+			} else {
+				sha = ref.Hash()
+			}
+			tagRefs[sha.String()] = ref.Name().Short()
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR addresses a bug where the incorrect commit SHA is being calculated for annotated tags (the code is currently using the SHA for the tag, not the commit).

I would normally have added test cases, but there doesn't appear to be any existing infra for that, and setting all that up was a bit out of scope (sorry 😬). I did test locally w/ a mix of annotated and lightweight tags and it works fine.

Fixes #17.
